### PR TITLE
Attempts fix for misspell action [pins version to v1.8.1]

### DIFF
--- a/.github/workflows/reviewdog_misspell.yml
+++ b/.github/workflows/reviewdog_misspell.yml
@@ -23,13 +23,14 @@ jobs:
         # step 1: usually used as first step (https://github.com/actions/checkout)
       - name: Check out code.
         uses: actions/checkout@v2
-        # step 2: imports other repos 
+        # step 2: imports other repos
       - name: misspell
         # this points to the given repository https://github.com/reviewdog/action-misspell
-        uses: reviewdog/action-misspell@master
+        uses: reviewdog/action-misspell@v1.8.1
         # parameters used by the repo
         with:
           github_token: ${{ secrets.github_token }}
-          locale: "US"
-          reporter: github-pr-check 
-          level: warning
+          locale: "UK"
+          reporter: github-pr-review
+          level: error
+          exclude: "*.css"


### PR DESCRIPTION
## Description
This PR attempts to fix the Github action misspell.
It was detected in this PR that the typo `collaboorating` was not caught.

The approach to fix it includes the following changes

## Changes
- [x] Pins the action version from `@master` to a deterministic stable version `@v1.8.1` (checked in other repo that has the action that this version works)
- [x] Updates the `level` from `warning` to `error`
- [x] Updates the reporter from `github-pr-check` (findings reported in the Actions tab) to `github-pr-review` which allows posting of comments from the reviewdog bot as conversation items.

Minor change that should have no effect to the attempt for the fix, only aesthetic/preference
- [X] Changes locale from `US` to `UK` 
- [X] Adds `exclude`  all CSS files from spell checking because for CSS the local is US.